### PR TITLE
docs: add run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,29 @@ This repository contains a Streamlit application for document analysis using RAG
 
 ## Running Locally
 
-Install the required packages and run Streamlit:
+Follow these steps to start the app on your machine:
+
+1. (Optional) Create and activate a virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Provide an OpenAI API key (see [Managing Secrets](#managing-secrets)).
+4. Launch Streamlit:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+Then open [http://localhost:8501](http://localhost:8501) in your browser.
+
+### Docker
+
+If you prefer running with Docker, use:
 
 ```bash
-pip install -r requirements.txt
-streamlit run app.py
+docker-compose up --build
 ```
 
 ## Managing Secrets


### PR DESCRIPTION
## Summary
- add step-by-step instructions for running the Streamlit app
- document Docker-based startup option

## Testing
- `pytest` *(fails: httpx not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b2a6c4fa48330b3e196627d7022ec