### PR TITLE
feat: add text classification utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,29 @@ This repository contains a Streamlit application for document analysis using RAG
 
 ## Running Locally
 
-Install the required packages and run Streamlit:
+Follow these steps to start the app on your machine:
+
+1. (Optional) Create and activate a virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Provide an OpenAI API key (see [Managing Secrets](#managing-secrets)).
+4. Launch Streamlit:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+Then open [http://localhost:8501](http://localhost:8501) in your browser.
+
+### Docker
+
+If you prefer running with Docker, use:
 
 ```bash
-pip install -r requirements.txt
-streamlit run app.py
+docker-compose up --build
 ```
 
 ## Managing Secrets
@@ -26,3 +44,17 @@ The application expects an OpenAI API key. You can provide it in two ways:
 
 Do **not** commit your actual `secrets.toml` file or any `.env` files. The provided `.gitignore` already excludes them to keep credentials private.
 
+
+## Text Classification
+
+A helper script `classification.py` trains a Naive Bayes text classifier
+from a CSV file and predicts labels for new questions.
+
+1. Prepare a CSV file with `text` and `label` columns.
+2. Run the script:
+
+   ```bash
+   python classification.py data.csv "질문 내용"
+   ```
+
+The script prints the predicted label based on the trained data.

--- a/classification.py
+++ b/classification.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Simple text classifier and question answering utility.
+
+This module trains a Naive Bayes classifier on labelled text data and
+uses it to classify new questions or cases.
+
+Usage::
+
+    python classification.py path/to/data.csv "새로운 질문"
+
+The CSV file must contain ``text`` and ``label`` columns.
+"""
+
+from dataclasses import dataclass
+from typing import List
+from pathlib import Path
+import argparse
+
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.naive_bayes import MultinomialNB
+
+
+@dataclass
+class TextClassifier:
+    """Wraps a TF-IDF vectorizer and Naive Bayes model."""
+
+    vectorizer: TfidfVectorizer
+    model: MultinomialNB
+
+    def predict(self, text: str) -> str:
+        """Return the predicted label for *text*."""
+        X = self.vectorizer.transform([text])
+        return self.model.predict(X)[0]
+
+
+def train_from_csv(csv_path: Path) -> TextClassifier:
+    """Train a classifier from a CSV with ``text`` and ``label`` columns."""
+    df = pd.read_csv(csv_path)
+    texts: List[str] = df["text"].astype(str).tolist()
+    labels: List[str] = df["label"].astype(str).tolist()
+
+    vectorizer = TfidfVectorizer()
+    X = vectorizer.fit_transform(texts)
+    model = MultinomialNB()
+    model.fit(X, labels)
+    return TextClassifier(vectorizer, model)
+
+
+def answer_question(classifier: TextClassifier, question: str) -> str:
+    """Classify *question* and return a human readable response."""
+    label = classifier.predict(question)
+    return f"Predicted label: {label}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train classifier and answer a question")
+    parser.add_argument("data", type=Path, help="CSV file with text and label columns")
+    parser.add_argument("question", help="New question or case text")
+    args = parser.parse_args()
+
+    clf = train_from_csv(args.data)
+    print(answer_question(clf, args.question))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ python-docx
 pypdf
 regex
 tqdm
+
+httpx
+scikit-learn

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import pandas as pd
+
+from classification import train_from_csv, answer_question
+
+
+def test_train_and_answer(tmp_path: Path):
+    data = pd.DataFrame(
+        {
+            "text": ["system error", "all good", "critical failure"],
+            "label": ["issue", "ok", "issue"],
+        }
+    )
+    csv = tmp_path / "data.csv"
+    data.to_csv(csv, index=False)
+
+    clf = train_from_csv(csv)
+    response = answer_question(clf, "there is a system error")
+    assert "issue" in response


### PR DESCRIPTION
## Summary
- include httpx and scikit-learn in requirements
- implement `classification.py` Naive Bayes classifier with CLI
- document classifier usage and add basic unit test

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b2a6c4fa48330b3e196627d7022ec